### PR TITLE
Prepare final v2.x release with v3 advert and redirect support

### DIFF
--- a/src/ImageSort.Localization/Text.Designer.cs
+++ b/src/ImageSort.Localization/Text.Designer.cs
@@ -341,6 +341,33 @@ namespace ImageSort.Localization {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Learn more at mediasort.app.
+        /// </summary>
+        public static string MediaSortAdButton {
+            get {
+                return ResourceManager.GetString("MediaSortAdButton", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Media Sort v3 is available!.
+        /// </summary>
+        public static string MediaSortAdHeader {
+            get {
+                return ResourceManager.GetString("MediaSortAdHeader", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Image Sort has been completely rewritten and is now Media Sort. It supports images, audio and video, and runs on Windows, macOS and Linux..
+        /// </summary>
+        public static string MediaSortAdText {
+            get {
+                return ResourceManager.GetString("MediaSortAdText", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Metadata.
         /// </summary>
         public static string MetadataPanelHeader {

--- a/src/ImageSort.Localization/Text.de-DE.resx
+++ b/src/ImageSort.Localization/Text.de-DE.resx
@@ -318,4 +318,13 @@ Wollen Sie updaten?</value>
   <data name="ShowInExplorerContextMenu" xml:space="preserve">
     <value>Verknüpfung zum Öffnen eines Ordners in Image Sort im Kontextmenü des Windows Explorers hinzufügen.</value>
   </data>
+  <data name="MediaSortAdHeader" xml:space="preserve">
+    <value>Media Sort v3 ist verfügbar!</value>
+  </data>
+  <data name="MediaSortAdText" xml:space="preserve">
+    <value>Image Sort wurde komplett neu entwickelt und heißt jetzt Media Sort. Es unterstützt Bilder, Audio und Video und läuft auf Windows, macOS und Linux.</value>
+  </data>
+  <data name="MediaSortAdButton" xml:space="preserve">
+    <value>Mehr erfahren auf mediasort.app</value>
+  </data>
 </root>

--- a/src/ImageSort.Localization/Text.resx
+++ b/src/ImageSort.Localization/Text.resx
@@ -318,4 +318,13 @@ Do you want to update?</value>
   <data name="ShowInExplorerContextMenu" xml:space="preserve">
     <value>Add a shortcut to open a folder in Image Sort directly from the context menu in Windows Explorer.</value>
   </data>
+  <data name="MediaSortAdHeader" xml:space="preserve">
+    <value>Media Sort v3 is available!</value>
+  </data>
+  <data name="MediaSortAdText" xml:space="preserve">
+    <value>Image Sort has been completely rewritten and is now Media Sort. It supports images, audio and video, and runs on Windows, macOS and Linux.</value>
+  </data>
+  <data name="MediaSortAdButton" xml:space="preserve">
+    <value>Learn more at mediasort.app</value>
+  </data>
 </root>

--- a/src/ImageSort.WPF/App.xaml.cs
+++ b/src/ImageSort.WPF/App.xaml.cs
@@ -181,9 +181,7 @@ public partial class App : System.Windows.Application
                     _ = InstallerRunner.RunAsync(installer);
                 }
             }
-        }
 
-        {
             var ghubClientV3 = new GitHubClient(new ProductHeaderValue("Image-Sort"));
             var updateFetcherV3 = new GitHubUpdateFetcher(ghubClientV3);
             var hasStableV3Release = await updateFetcherV3.HasStableV3ReleaseAsync().ConfigureAwait(true);

--- a/src/ImageSort.WPF/App.xaml.cs
+++ b/src/ImageSort.WPF/App.xaml.cs
@@ -178,13 +178,14 @@ public partial class App : System.Windows.Application
                 {
                     var installer = await updateFetcher.GetStreamFromAssetAsync(installerAsset).ConfigureAwait(false);
 
-                    _ = InstallerRunner.RunAsync(installer);
+                    if (installer != null)
+                    {
+                        _ = InstallerRunner.RunAsync(installer);
+                    }
                 }
             }
 
-            var ghubClientV3 = new GitHubClient(new ProductHeaderValue("Image-Sort"));
-            var updateFetcherV3 = new GitHubUpdateFetcher(ghubClientV3);
-            var hasStableV3Release = await updateFetcherV3.HasStableV3ReleaseAsync().ConfigureAwait(true);
+            var hasStableV3Release = await updateFetcher.HasStableV3ReleaseAsync().ConfigureAwait(true);
             ImageSort.WPF.MainWindow.MediaSortV3Available = hasStableV3Release;
 
             if (hasStableV3Release && this.MainWindow is ImageSort.WPF.MainWindow mainWindow)

--- a/src/ImageSort.WPF/App.xaml.cs
+++ b/src/ImageSort.WPF/App.xaml.cs
@@ -157,7 +157,7 @@ public partial class App : System.Windows.Application
         {
             var ghubClient = new GitHubClient(new ProductHeaderValue("Image-Sort"));
             var updateFetcher = new GitHubUpdateFetcher(ghubClient);
-            (var success, var release) = 
+            (var success, var release, var hasStableV3Release) = 
                 await updateFetcher.TryGetLatestReleaseAsync(generalSettings.InstallPrereleaseBuilds).ConfigureAwait(true);
 
             if (success)
@@ -185,7 +185,6 @@ public partial class App : System.Windows.Application
                 }
             }
 
-            var hasStableV3Release = await updateFetcher.HasStableV3ReleaseAsync().ConfigureAwait(true);
             ImageSort.WPF.MainWindow.MediaSortV3Available = hasStableV3Release;
 
             if (hasStableV3Release && this.MainWindow is ImageSort.WPF.MainWindow mainWindow)

--- a/src/ImageSort.WPF/App.xaml.cs
+++ b/src/ImageSort.WPF/App.xaml.cs
@@ -153,32 +153,45 @@ public partial class App : System.Windows.Application
             .OfType<GeneralSettingsGroupViewModel>()
             .Single();
 
-        if (!generalSettings.CheckForUpdatesOnStartup) return;
-
-        var ghubClient = new GitHubClient(new ProductHeaderValue("Image-Sort"));
-        var updateFetcher = new GitHubUpdateFetcher(ghubClient);
-        (var success, var release) = 
-            await updateFetcher.TryGetLatestReleaseAsync(generalSettings.InstallPrereleaseBuilds).ConfigureAwait(true);
-
-        if (success)
+        if (generalSettings.CheckForUpdatesOnStartup)
         {
-            var messageBox = new MessageBoxModel
+            var ghubClient = new GitHubClient(new ProductHeaderValue("Image-Sort"));
+            var updateFetcher = new GitHubUpdateFetcher(ghubClient);
+            (var success, var release) = 
+                await updateFetcher.TryGetLatestReleaseAsync(generalSettings.InstallPrereleaseBuilds).ConfigureAwait(true);
+
+            if (success)
             {
-                Caption = Text.UpdateAvailablePromptTitle,
-                Text = Text.UpdateAvailablePromptText.Replace("{TagName}", release.TagName ?? "NO TAG INFORMATION AVAILABLE", StringComparison.OrdinalIgnoreCase),
-                Buttons = new[]
+                var messageBox = new MessageBoxModel
                 {
-                    MessageBoxButtons.Yes(Text.Update),
-                    MessageBoxButtons.No(Text.DoNotUpdate)
-                },
-                Icon = AdonisUI.Controls.MessageBoxImage.Question
-            };
+                    Caption = Text.UpdateAvailablePromptTitle,
+                    Text = Text.UpdateAvailablePromptText.Replace("{TagName}", release.TagName ?? "NO TAG INFORMATION AVAILABLE", StringComparison.OrdinalIgnoreCase),
+                    Buttons = new[]
+                    {
+                        MessageBoxButtons.Yes(Text.Update),
+                        MessageBoxButtons.No(Text.DoNotUpdate)
+                    },
+                    Icon = AdonisUI.Controls.MessageBoxImage.Question
+                };
 
-            if (AdonisUI.Controls.MessageBox.Show(messageBox) == AdonisUI.Controls.MessageBoxResult.Yes && updateFetcher.TryGetInstallerFromRelease(release, out var installerAsset))
+                if (AdonisUI.Controls.MessageBox.Show(messageBox) == AdonisUI.Controls.MessageBoxResult.Yes && updateFetcher.TryGetInstallerFromRelease(release, out var installerAsset))
+                {
+                    var installer = await updateFetcher.GetStreamFromAssetAsync(installerAsset).ConfigureAwait(false);
+
+                    InstallerRunner.RunAsync(installer).ConfigureAwait(false);
+                }
+            }
+        }
+
+        {
+            var ghubClientV3 = new GitHubClient(new ProductHeaderValue("Image-Sort"));
+            var updateFetcherV3 = new GitHubUpdateFetcher(ghubClientV3);
+            var hasStableV3Release = await updateFetcherV3.HasStableV3ReleaseAsync().ConfigureAwait(true);
+            MainWindow.MediaSortV3Available = hasStableV3Release;
+
+            if (hasStableV3Release && this.MainWindow is MainWindow mainWindow)
             {
-                var installer = await updateFetcher.GetStreamFromAssetAsync(installerAsset).ConfigureAwait(false);
-
-                InstallerRunner.RunAsync(installer).ConfigureAwait(false);
+                mainWindow.ShowMediaSortAd();
             }
         }
 #endif

--- a/src/ImageSort.WPF/App.xaml.cs
+++ b/src/ImageSort.WPF/App.xaml.cs
@@ -178,7 +178,7 @@ public partial class App : System.Windows.Application
                 {
                     var installer = await updateFetcher.GetStreamFromAssetAsync(installerAsset).ConfigureAwait(false);
 
-                    InstallerRunner.RunAsync(installer).ConfigureAwait(false);
+                    _ = InstallerRunner.RunAsync(installer);
                 }
             }
         }
@@ -187,9 +187,9 @@ public partial class App : System.Windows.Application
             var ghubClientV3 = new GitHubClient(new ProductHeaderValue("Image-Sort"));
             var updateFetcherV3 = new GitHubUpdateFetcher(ghubClientV3);
             var hasStableV3Release = await updateFetcherV3.HasStableV3ReleaseAsync().ConfigureAwait(true);
-            MainWindow.MediaSortV3Available = hasStableV3Release;
+            ImageSort.WPF.MainWindow.MediaSortV3Available = hasStableV3Release;
 
-            if (hasStableV3Release && this.MainWindow is MainWindow mainWindow)
+            if (hasStableV3Release && this.MainWindow is ImageSort.WPF.MainWindow mainWindow)
             {
                 mainWindow.ShowMediaSortAd();
             }

--- a/src/ImageSort.WPF/App.xaml.cs
+++ b/src/ImageSort.WPF/App.xaml.cs
@@ -176,7 +176,7 @@ public partial class App : System.Windows.Application
 
                 if (AdonisUI.Controls.MessageBox.Show(messageBox) == AdonisUI.Controls.MessageBoxResult.Yes && updateFetcher.TryGetInstallerFromRelease(release, out var installerAsset))
                 {
-                    var installer = await updateFetcher.GetStreamFromAssetAsync(installerAsset).ConfigureAwait(false);
+                    var installer = await updateFetcher.GetStreamFromAssetAsync(installerAsset).ConfigureAwait(true);
 
                     if (installer != null)
                     {

--- a/src/ImageSort.WPF/MainWindow.xaml
+++ b/src/ImageSort.WPF/MainWindow.xaml
@@ -25,6 +25,16 @@
         <GroupBox Grid.Column="2" Margin="{adonisUi:Space 0, 1, 1, 1}">
             <StackPanel VerticalAlignment="Center">
 
+                <GroupBox x:Name="MediaSortAd" Header="{x:Static text:Text.MediaSortAdHeader}"
+                          Margin="{adonisUi:Space 0, 0, 0, 1}" Visibility="Collapsed">
+                    <StackPanel>
+                        <TextBlock Text="{x:Static text:Text.MediaSortAdText}"
+                                   TextWrapping="Wrap" Margin="{adonisUi:Space 0, 0, 0, 0.5}" />
+                        <Button Content="{x:Static text:Text.MediaSortAdButton}"
+                                Click="OnMediaSortAdClicked" />
+                    </StackPanel>
+                </GroupBox>
+
                 <GroupBox Header="{x:Static text:Text.Folder}" Margin="{adonisUi:Space 0, 1}">
                     <StackPanel>
                         <Button Content="{x:Static text:Text.OpenFolder}" x:Name="OpenFolder" />

--- a/src/ImageSort.WPF/MainWindow.xaml.cs
+++ b/src/ImageSort.WPF/MainWindow.xaml.cs
@@ -11,6 +11,7 @@ using System.Windows.Forms;
 using System.Windows.Input;
 using System.Windows.Interop;
 using System.Windows.Media;
+using System.Windows.Threading;
 using AdonisUI.Controls;
 using ImageSort.Localization;
 using ImageSort.SettingsManagement;
@@ -309,12 +310,20 @@ public partial class MainWindow : AdonisWindow, IViewFor<MainViewModel>
 
     private void OnMediaSortAdClicked(object sender, RoutedEventArgs e)
     {
-        Process.Start(new ProcessStartInfo("https://mediasort.app") { UseShellExecute = true });
+        try
+        {
+            Process.Start(new ProcessStartInfo("https://mediasort.app") { UseShellExecute = true });
+        }
+        catch
+        {
+            // ignored — browser may not be available
+        }
     }
 
     public void ShowMediaSortAd()
     {
-        Dispatcher.Invoke(() => MediaSortAd.Visibility = Visibility.Visible);
+        if (Dispatcher.HasShutdownStarted || Dispatcher.HasShutdownFinished) return;
+        Dispatcher.BeginInvoke(() => MediaSortAd.Visibility = Visibility.Visible);
     }
 
     #region IViewFor implementation

--- a/src/ImageSort.WPF/MainWindow.xaml.cs
+++ b/src/ImageSort.WPF/MainWindow.xaml.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Diagnostics;
 using System.Linq;
 using System.Reactive;
 using System.Reactive.Disposables;
@@ -34,6 +35,8 @@ public partial class MainWindow : AdonisWindow, IViewFor<MainViewModel>
 {
     private bool interceptReservedKeys = true;
 
+    public static bool MediaSortV3Available { get; set; }
+
     public MainWindow()
     {
         InitializeComponent();
@@ -55,6 +58,11 @@ public partial class MainWindow : AdonisWindow, IViewFor<MainViewModel>
         var settings = Locator.Current.GetService<SettingsViewModel>();
 
         Closed += async (o, e) => await settings.SaveAsync().ConfigureAwait(false);
+
+        Loaded += (_, _) =>
+        {
+            if (MediaSortV3Available) ShowMediaSortAd();
+        };
 
         this.WhenActivated(disposableRegistration =>
         {
@@ -297,6 +305,16 @@ public partial class MainWindow : AdonisWindow, IViewFor<MainViewModel>
         CreditsWindow.Window.Show();
         CreditsWindow.Window
             .Activate(); // make sure the window ends up in the foreground when already open to avoid confusion
+    }
+
+    private void OnMediaSortAdClicked(object sender, RoutedEventArgs e)
+    {
+        Process.Start(new ProcessStartInfo("https://mediasort.app") { UseShellExecute = true });
+    }
+
+    public void ShowMediaSortAd()
+    {
+        Dispatcher.Invoke(() => MediaSortAd.Visibility = Visibility.Visible);
     }
 
     #region IViewFor implementation

--- a/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
+++ b/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -20,7 +21,7 @@ public class GitHubUpdateFetcher
         this.client = client;
     }
 
-    public async Task<(bool, Release)> TryGetLatestReleaseAsync(bool allowPrerelease = false)
+    public async Task<(bool updateFound, Release release, bool hasStableV3)> TryGetLatestReleaseAsync(bool allowPrerelease = false)
     {
         var assembly = Assembly.GetAssembly(typeof(GitHubUpdateFetcher));
         var gitVersionInformationType = assembly.GetType("GitVersionInformation");
@@ -28,7 +29,7 @@ public class GitHubUpdateFetcher
             (string) gitVersionInformationType?.GetFields().First(f => f.Name == "SemVer").GetValue(null);
         var version = SemVersion.Parse(versionTag, SemVersionStyles.Any);
 
-        Release latestFitting;
+        Release latestFitting = null;
 
         try
         {
@@ -49,28 +50,16 @@ public class GitHubUpdateFetcher
                     return prereleaseCondition && isNewVersion;
                 })
                 .FirstOrDefault();
-        }
-        catch
-        {
-            latestFitting = null;
-        }
 
-        return (latestFitting != null, latestFitting);
-    }
-
-    public async Task<bool> HasStableV3ReleaseAsync()
-    {
-        try
-        {
-            var releases = await client.Repository.Release.GetAll(RepoOwner, RepoName);
-
-            return releases
+            var hasStableV3 = releases
                 .Where(release => IsV3Release(release.TagName))
                 .Any(release => !release.Prerelease);
+
+            return (latestFitting != null, latestFitting, hasStableV3);
         }
         catch
         {
-            return false;
+            return (false, null, false);
         }
     }
 
@@ -118,7 +107,8 @@ public class GitHubUpdateFetcher
 
         try
         {
-            return await httpClient.GetStreamAsync(asset.BrowserDownloadUrl);
+            var responseBytes = await httpClient.GetByteArrayAsync(asset.BrowserDownloadUrl);
+            return new MemoryStream(responseBytes);
         }
         catch (HttpRequestException)
         {

--- a/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
+++ b/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -77,18 +76,20 @@ public class GitHubUpdateFetcher
 
     private static bool IsV2Release(string tagName)
     {
+        if (string.IsNullOrEmpty(tagName)) return false;
         var firstIndexOfV = tagName.IndexOf('v', StringComparison.OrdinalIgnoreCase);
         if (firstIndexOfV < 0) return false;
         var versionPart = tagName.Substring(firstIndexOfV + 1);
-        return versionPart.StartsWith("2.");
+        return versionPart.StartsWith("2.", StringComparison.Ordinal);
     }
 
     private static bool IsV3Release(string tagName)
     {
+        if (string.IsNullOrEmpty(tagName)) return false;
         var firstIndexOfV = tagName.IndexOf('v', StringComparison.OrdinalIgnoreCase);
         if (firstIndexOfV < 0) return false;
         var versionPart = tagName.Substring(firstIndexOfV + 1);
-        return versionPart.StartsWith("3.");
+        return versionPart.StartsWith("3.", StringComparison.Ordinal);
     }
 
     public bool TryGetInstallerFromRelease(Release release, out ReleaseAsset installer)

--- a/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
+++ b/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
@@ -42,8 +42,10 @@ public class GitHubUpdateFetcher
                     var prereleaseCondition = allowPrerelease || !release.Prerelease;
 
                     var firstIndexOfV = release.TagName.IndexOf('v', StringComparison.OrdinalIgnoreCase);
+                    var versionString = release.TagName.Substring(firstIndexOfV + 1);
 
-                    var releaseVersion = SemVersion.Parse(release.TagName.Substring(firstIndexOfV + 1), SemVersionStyles.Any);
+                    if (!SemVersion.TryParse(versionString, SemVersionStyles.Any, out var releaseVersion))
+                        return false;
 
                     var isNewVersion = version.ComparePrecedenceTo(releaseVersion) < 0;
 

--- a/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
+++ b/src/ImageSort.WindowsUpdater/GitHubUpdateFetcher.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -12,6 +13,8 @@ namespace ImageSort.WindowsUpdater;
 public class GitHubUpdateFetcher
 {
     private readonly GitHubClient client;
+    private const string RepoOwner = "Lolle2000la";
+    private const string RepoName = "Image-Sort";
 
     public GitHubUpdateFetcher(GitHubClient client)
     {
@@ -30,10 +33,11 @@ public class GitHubUpdateFetcher
 
         try
         {
-            var releases = await client.Repository.Release.GetAll("Lolle2000la", "Image-Sort");
+            var releases = await client.Repository.Release.GetAll(RepoOwner, RepoName);
 
             latestFitting = releases
-                .FirstOrDefault(release =>
+                .Where(release => IsV2Release(release.TagName))
+                .Where(release =>
                 {
                     var prereleaseCondition = allowPrerelease || !release.Prerelease;
 
@@ -44,7 +48,8 @@ public class GitHubUpdateFetcher
                     var isNewVersion = version.ComparePrecedenceTo(releaseVersion) < 0;
 
                     return prereleaseCondition && isNewVersion;
-                });
+                })
+                .FirstOrDefault();
         }
         catch
         {
@@ -52,6 +57,38 @@ public class GitHubUpdateFetcher
         }
 
         return (latestFitting != null, latestFitting);
+    }
+
+    public async Task<bool> HasStableV3ReleaseAsync()
+    {
+        try
+        {
+            var releases = await client.Repository.Release.GetAll(RepoOwner, RepoName);
+
+            return releases
+                .Where(release => IsV3Release(release.TagName))
+                .Any(release => !release.Prerelease);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool IsV2Release(string tagName)
+    {
+        var firstIndexOfV = tagName.IndexOf('v', StringComparison.OrdinalIgnoreCase);
+        if (firstIndexOfV < 0) return false;
+        var versionPart = tagName.Substring(firstIndexOfV + 1);
+        return versionPart.StartsWith("2.");
+    }
+
+    private static bool IsV3Release(string tagName)
+    {
+        var firstIndexOfV = tagName.IndexOf('v', StringComparison.OrdinalIgnoreCase);
+        if (firstIndexOfV < 0) return false;
+        var versionPart = tagName.Substring(firstIndexOfV + 1);
+        return versionPart.StartsWith("3.");
     }
 
     public bool TryGetInstallerFromRelease(Release release, out ReleaseAsset installer)
@@ -69,7 +106,12 @@ public class GitHubUpdateFetcher
 
     public async Task<Stream> GetStreamFromAssetAsync(ReleaseAsset asset)
     {
-        using var httpClient = new HttpClient();
+        var handler = new HttpClientHandler
+        {
+            AllowAutoRedirect = true
+        };
+
+        using var httpClient = new HttpClient(handler);
 
         httpClient.DefaultRequestHeaders.Add("User-Agent", "Image-Sort");
 


### PR DESCRIPTION
- Updater now targets the (soon-to-be-renamed) repo; follows redirects for MSI downloads via HttpClientHandler.AllowAutoRedirect
- Filter releases to v2.x tags only so v3.x releases are ignored
- Add v3.x stable release detection and show an advert banner in the middle section linking to https://mediasort.app
- Add English and German localization for the Media Sort advert