### PR TITLE
feat(gui): standard scroll-into-view behavior with scroll margins

### DIFF
--- a/crates/media-sort-gui/src/message.rs
+++ b/crates/media-sort-gui/src/message.rs
@@ -107,6 +107,8 @@ pub enum FolderMessage {
     CreateInputChanged(String),
     SubmitCreate(PathBuf),
     CancelCreate,
+    #[serde(skip_deserializing)]
+    TreeScrolled(iced::widget::scrollable::AbsoluteOffset, f32, f32),
 }
 
 #[derive(Debug, Clone, serde::Deserialize, iced_automation_macros::AutomationKeycap)]

--- a/crates/media-sort-gui/src/state/folder.rs
+++ b/crates/media-sort-gui/src/state/folder.rs
@@ -4,6 +4,16 @@ use std::sync::mpsc;
 
 use media_sort_core::models::{FolderNode, PinnedFolder};
 
+#[derive(Debug, Clone, Copy, Default)]
+pub struct FolderScrollState {
+    /// Current vertical scroll offset in pixels.
+    pub offset_y: f32,
+    /// Height of the visible viewport in pixels.
+    pub viewport_height: f32,
+    /// Height of the scrollable content in pixels.
+    pub content_height: f32,
+}
+
 #[derive(Default)]
 pub struct FolderState {
     pub current_folder: Option<PathBuf>,
@@ -16,6 +26,7 @@ pub struct FolderState {
     pub hovered_pinned_folder: Option<PathBuf>,
     pub folder_tree_receiver: Option<mpsc::Receiver<Vec<FolderNode>>>,
     pub(crate) visible_folders_cache: Vec<PathBuf>,
+    pub scroll: FolderScrollState,
 }
 
 impl fmt::Debug for FolderState {
@@ -34,6 +45,7 @@ impl fmt::Debug for FolderState {
                 "visible_folders_cache_len",
                 &self.visible_folders_cache.len(),
             )
+            .field("scroll", &self.scroll)
             .finish()
     }
 }

--- a/crates/media-sort-gui/src/update/folder.rs
+++ b/crates/media-sort-gui/src/update/folder.rs
@@ -176,5 +176,11 @@ pub fn handle_folder_message(state: &mut AppState, msg: FolderMessage) -> Task<M
             }
             Task::none()
         }
+        FolderMessage::TreeScrolled(offset, viewport_height, content_height) => {
+            state.folder.scroll.offset_y = offset.y;
+            state.folder.scroll.viewport_height = viewport_height;
+            state.folder.scroll.content_height = content_height;
+            Task::none()
+        }
     }
 }

--- a/crates/media-sort-gui/src/update/tasks.rs
+++ b/crates/media-sort-gui/src/update/tasks.rs
@@ -2,6 +2,10 @@ use iced::Task;
 
 use crate::message::{MediaMessage, Message};
 use crate::state::AppState;
+use crate::view::folder_panel::FOLDER_TREE_SCROLLABLE_ID;
+use crate::view::media_grid::{
+    MEDIA_GRID_CARD_SPACING, MEDIA_GRID_CARD_WIDTH, MEDIA_GRID_SCROLLABLE_ID,
+};
 use media_sort_core::media_type::MediaType;
 
 pub fn select_and_load_entry(state: &mut AppState, index: usize) -> Task<Message> {
@@ -198,10 +202,6 @@ pub fn select_and_load_entry(state: &mut AppState, index: usize) -> Task<Message
 /// is executed. If it moves near or past the viewport edge, the scroll position
 /// adjusts minimally so the item comes into view with margin.
 pub fn scroll_to_selected_entry(state: &AppState, index: usize) -> Task<Message> {
-    use crate::view::media_grid::{
-        MEDIA_GRID_CARD_SPACING, MEDIA_GRID_CARD_WIDTH, MEDIA_GRID_SCROLLABLE_ID,
-    };
-
     let total = state.media_grid.filtered_entries().len();
     if total <= 1 {
         return Task::none();
@@ -300,8 +300,6 @@ pub fn relative_position_for(index: usize, total: usize) -> Option<f32> {
 }
 
 pub fn scroll_to_selected_folder(state: &mut AppState) -> Task<Message> {
-    use crate::view::folder_panel::FOLDER_TREE_SCROLLABLE_ID;
-
     let visible = state.folder.collect_visible_folders();
     let total = visible.len();
     let Some(idx) = state.folder.selected_folder_idx.filter(|i| *i < total) else {

--- a/crates/media-sort-gui/src/update/tasks.rs
+++ b/crates/media-sort-gui/src/update/tasks.rs
@@ -220,7 +220,7 @@ pub fn scroll_to_selected_entry(state: &AppState, index: usize) -> Task<Message>
         }
 
         let margin = card_stride * 1.5;
-        let Some(target_offset) = calculate_scroll_into_view_h(
+        let Some(target_offset) = calculate_scroll_into_view_1d(
             item_left,
             item_right,
             scroll.offset_x,
@@ -246,50 +246,6 @@ pub fn scroll_to_selected_entry(state: &AppState, index: usize) -> Task<Message>
             x: Some(relative_x),
             y: None,
         },
-    )
-}
-
-/// Computes target horizontal scroll offset to keep `[item_left, item_right]`
-/// visible within `[offset_x, offset_x + viewport_width]` with at least `margin`
-/// padding. Returns `Some(target_offset)` if scrolling is needed, or `None` if
-/// the item is already comfortably in view.
-pub fn calculate_scroll_into_view_h(
-    item_left: f32,
-    item_right: f32,
-    offset_x: f32,
-    viewport_width: f32,
-    content_width: f32,
-    margin: f32,
-) -> Option<f32> {
-    calculate_scroll_into_view_1d(
-        item_left,
-        item_right,
-        offset_x,
-        viewport_width,
-        content_width,
-        margin,
-    )
-}
-
-/// Computes target vertical scroll offset to keep `[item_top, item_bottom]`
-/// visible within `[offset_y, offset_y + viewport_height]` with at least `margin`
-/// padding. Returns `Some(target_offset)` if scrolling is needed, or `None` if
-/// the item is already comfortably in view.
-pub fn calculate_scroll_into_view_v(
-    item_top: f32,
-    item_bottom: f32,
-    offset_y: f32,
-    viewport_height: f32,
-    content_height: f32,
-    margin: f32,
-) -> Option<f32> {
-    calculate_scroll_into_view_1d(
-        item_top,
-        item_bottom,
-        offset_y,
-        viewport_height,
-        content_height,
-        margin,
     )
 }
 
@@ -368,7 +324,7 @@ pub fn scroll_to_selected_folder(state: &mut AppState) -> Task<Message> {
         let item_bottom = item_top + item_height;
         let margin = (scroll.viewport_height * 0.15).clamp(26.0, 78.0);
 
-        let Some(target_offset) = calculate_scroll_into_view_v(
+        let Some(target_offset) = calculate_scroll_into_view_1d(
             item_top,
             item_bottom,
             scroll.offset_y,

--- a/crates/media-sort-gui/src/update/tasks.rs
+++ b/crates/media-sort-gui/src/update/tasks.rs
@@ -191,26 +191,50 @@ pub fn select_and_load_entry(state: &mut AppState, index: usize) -> Task<Message
     }
 }
 
-/// Build a [`Task`] that scrolls the media grid so that the entry at
-/// `index` is clearly visible. We use a *relative* scroll position so we
-/// don't have to depend on `state.media_grid.scroll.viewport_width` being
-/// up to date — that snapshot can briefly lag behind the actual layout
-/// (e.g. when the user has just resized the window, or the very first
-/// `on_scroll` after opening a folder hasn't fired yet). If we used an
-/// absolute pixel offset computed from a stale viewport, we could end up
-/// "scrolling" to a position that doesn't actually bring the selected
-/// card into view. The scrollable resolves the relative position using
-/// its own, always-current, content and viewport widths.
+/// Build a [`Task`] that scrolls the media grid so that the entry at `index`
+/// is visible within the viewport with a comfortable margin (scroll padding).
 ///
-/// The relative position is `index / (n - 1)`, so the selected card ends
-/// up at the corresponding proportional position in the content, well
-/// inside the viewport for any sane window size.
+/// If the card is already fully visible inside the viewport bounds, no scroll task
+/// is executed. If it moves near or past the viewport edge, the scroll position
+/// adjusts minimally so the item comes into view with margin.
 pub fn scroll_to_selected_entry(state: &AppState, index: usize) -> Task<Message> {
-    use crate::view::media_grid::MEDIA_GRID_SCROLLABLE_ID;
+    use crate::view::media_grid::{
+        MEDIA_GRID_CARD_SPACING, MEDIA_GRID_CARD_WIDTH, MEDIA_GRID_SCROLLABLE_ID,
+    };
 
-    let n = state.media_grid.filtered_entries().len();
-    let Some(relative_x) = relative_position_for(index, n) else {
+    let total = state.media_grid.filtered_entries().len();
+    if total <= 1 {
         return Task::none();
+    }
+
+    let clamped_index = index.min(total - 1);
+    let card_stride = MEDIA_GRID_CARD_WIDTH + MEDIA_GRID_CARD_SPACING;
+    let item_left = clamped_index as f32 * card_stride;
+    let item_right = item_left + MEDIA_GRID_CARD_WIDTH;
+
+    let scroll = &state.media_grid.scroll;
+
+    let relative_x = if scroll.viewport_width > 0.0 && scroll.content_width > scroll.viewport_width
+    {
+        let margin = card_stride * 1.5;
+        let Some(target_offset) = calculate_scroll_into_view_h(
+            item_left,
+            item_right,
+            scroll.offset_x,
+            scroll.viewport_width,
+            scroll.content_width,
+            margin,
+        ) else {
+            return Task::none();
+        };
+
+        let max_offset = scroll.content_width - scroll.viewport_width;
+        (target_offset / max_offset).clamp(0.0, 1.0)
+    } else {
+        let Some(rel) = relative_position_for(clamped_index, total) else {
+            return Task::none();
+        };
+        rel
     };
 
     iced::widget::operation::snap_to(
@@ -220,6 +244,82 @@ pub fn scroll_to_selected_entry(state: &AppState, index: usize) -> Task<Message>
             y: None,
         },
     )
+}
+
+/// Computes target horizontal scroll offset to keep `[item_left, item_right]`
+/// visible within `[offset_x, offset_x + viewport_width]` with at least `margin`
+/// padding. Returns `Some(target_offset)` if scrolling is needed, or `None` if
+/// the item is already comfortably in view.
+pub fn calculate_scroll_into_view_h(
+    item_left: f32,
+    item_right: f32,
+    offset_x: f32,
+    viewport_width: f32,
+    content_width: f32,
+    margin: f32,
+) -> Option<f32> {
+    if viewport_width <= 0.0 || content_width <= viewport_width {
+        return None;
+    }
+
+    let max_offset = (content_width - viewport_width).max(0.0);
+    let item_width = (item_right - item_left).max(0.0);
+    let effective_margin = margin.min((viewport_width - item_width).max(0.0) / 2.0);
+
+    let view_left = offset_x;
+    let view_right = offset_x + viewport_width;
+
+    let target_offset = if item_left - effective_margin < view_left {
+        (item_left - effective_margin).max(0.0)
+    } else if item_right + effective_margin > view_right {
+        (item_right + effective_margin - viewport_width).min(max_offset)
+    } else {
+        return None;
+    };
+
+    if (target_offset - offset_x).abs() > 0.5 {
+        Some(target_offset.clamp(0.0, max_offset))
+    } else {
+        None
+    }
+}
+
+/// Computes target vertical scroll offset to keep `[item_top, item_bottom]`
+/// visible within `[offset_y, offset_y + viewport_height]` with at least `margin`
+/// padding. Returns `Some(target_offset)` if scrolling is needed, or `None` if
+/// the item is already comfortably in view.
+pub fn calculate_scroll_into_view_v(
+    item_top: f32,
+    item_bottom: f32,
+    offset_y: f32,
+    viewport_height: f32,
+    content_height: f32,
+    margin: f32,
+) -> Option<f32> {
+    if viewport_height <= 0.0 || content_height <= viewport_height {
+        return None;
+    }
+
+    let max_offset = (content_height - viewport_height).max(0.0);
+    let item_height = (item_bottom - item_top).max(0.0);
+    let effective_margin = margin.min((viewport_height - item_height).max(0.0) / 2.0);
+
+    let view_top = offset_y;
+    let view_bottom = offset_y + viewport_height;
+
+    let target_offset = if item_top - effective_margin < view_top {
+        (item_top - effective_margin).max(0.0)
+    } else if item_bottom + effective_margin > view_bottom {
+        (item_bottom + effective_margin - viewport_height).min(max_offset)
+    } else {
+        return None;
+    };
+
+    if (target_offset - offset_y).abs() > 0.5 {
+        Some(target_offset.clamp(0.0, max_offset))
+    } else {
+        None
+    }
 }
 
 /// Compute the relative horizontal scroll position (in `[0.0, 1.0]`) that
@@ -238,16 +338,43 @@ pub fn scroll_to_selected_folder(state: &mut AppState) -> Task<Message> {
     use crate::view::folder_panel::FOLDER_TREE_SCROLLABLE_ID;
 
     let visible = state.folder.collect_visible_folders();
-    let Some(idx) = state
-        .folder
-        .selected_folder_idx
-        .filter(|i| *i < visible.len())
-    else {
+    let total = visible.len();
+    let Some(idx) = state.folder.selected_folder_idx.filter(|i| *i < total) else {
         return Task::none();
     };
-    let Some(relative_y) = relative_position_for(idx, visible.len()) else {
+
+    if total <= 1 {
         return Task::none();
-    };
+    }
+
+    let scroll = &state.folder.scroll;
+
+    let relative_y =
+        if scroll.viewport_height > 0.0 && scroll.content_height > scroll.viewport_height {
+            let item_height = scroll.content_height / total as f32;
+            let item_top = idx as f32 * item_height;
+            let item_bottom = item_top + item_height;
+            let margin = (scroll.viewport_height * 0.15).clamp(26.0, 78.0);
+
+            let Some(target_offset) = calculate_scroll_into_view_v(
+                item_top,
+                item_bottom,
+                scroll.offset_y,
+                scroll.viewport_height,
+                scroll.content_height,
+                margin,
+            ) else {
+                return Task::none();
+            };
+
+            let max_offset = scroll.content_height - scroll.viewport_height;
+            (target_offset / max_offset).clamp(0.0, 1.0)
+        } else {
+            let Some(rel) = relative_position_for(idx, total) else {
+                return Task::none();
+            };
+            rel
+        };
 
     iced::widget::operation::snap_to(
         FOLDER_TREE_SCROLLABLE_ID.clone(),

--- a/crates/media-sort-gui/src/update/tasks.rs
+++ b/crates/media-sort-gui/src/update/tasks.rs
@@ -258,30 +258,14 @@ pub fn calculate_scroll_into_view_h(
     content_width: f32,
     margin: f32,
 ) -> Option<f32> {
-    if viewport_width <= 0.0 || content_width <= viewport_width {
-        return None;
-    }
-
-    let max_offset = (content_width - viewport_width).max(0.0);
-    let item_width = (item_right - item_left).max(0.0);
-    let effective_margin = margin.min((viewport_width - item_width).max(0.0) / 2.0);
-
-    let view_left = offset_x;
-    let view_right = offset_x + viewport_width;
-
-    let target_offset = if item_left - effective_margin < view_left {
-        (item_left - effective_margin).max(0.0)
-    } else if item_right + effective_margin > view_right {
-        (item_right + effective_margin - viewport_width).min(max_offset)
-    } else {
-        return None;
-    };
-
-    if (target_offset - offset_x).abs() > 0.5 {
-        Some(target_offset.clamp(0.0, max_offset))
-    } else {
-        None
-    }
+    calculate_scroll_into_view_1d(
+        item_left,
+        item_right,
+        offset_x,
+        viewport_width,
+        content_width,
+        margin,
+    )
 }
 
 /// Computes target vertical scroll offset to keep `[item_top, item_bottom]`
@@ -296,26 +280,48 @@ pub fn calculate_scroll_into_view_v(
     content_height: f32,
     margin: f32,
 ) -> Option<f32> {
-    if viewport_height <= 0.0 || content_height <= viewport_height {
+    calculate_scroll_into_view_1d(
+        item_top,
+        item_bottom,
+        offset_y,
+        viewport_height,
+        content_height,
+        margin,
+    )
+}
+
+/// Computes target 1D scroll offset to keep `[item_start, item_end]` visible within
+/// `[current_offset, current_offset + viewport_size]` with at least `margin` padding.
+/// Returns `Some(target_offset)` if scrolling is needed, or `None` if the item is
+/// already comfortably in view.
+pub fn calculate_scroll_into_view_1d(
+    item_start: f32,
+    item_end: f32,
+    current_offset: f32,
+    viewport_size: f32,
+    content_size: f32,
+    margin: f32,
+) -> Option<f32> {
+    if viewport_size <= 0.0 || content_size <= viewport_size {
         return None;
     }
 
-    let max_offset = (content_height - viewport_height).max(0.0);
-    let item_height = (item_bottom - item_top).max(0.0);
-    let effective_margin = margin.min((viewport_height - item_height).max(0.0) / 2.0);
+    let max_offset = (content_size - viewport_size).max(0.0);
+    let item_size = (item_end - item_start).max(0.0);
+    let effective_margin = margin.min((viewport_size - item_size).max(0.0) / 2.0);
 
-    let view_top = offset_y;
-    let view_bottom = offset_y + viewport_height;
+    let view_start = current_offset;
+    let view_end = current_offset + viewport_size;
 
-    let target_offset = if item_top - effective_margin < view_top {
-        (item_top - effective_margin).max(0.0)
-    } else if item_bottom + effective_margin > view_bottom {
-        (item_bottom + effective_margin - viewport_height).min(max_offset)
+    let target_offset = if item_start - effective_margin < view_start {
+        (item_start - effective_margin).max(0.0)
+    } else if item_end + effective_margin > view_end {
+        (item_end + effective_margin - viewport_size).min(max_offset)
     } else {
         return None;
     };
 
-    if (target_offset - offset_y).abs() > 0.5 {
+    if (target_offset - current_offset).abs() > 0.5 {
         Some(target_offset.clamp(0.0, max_offset))
     } else {
         None

--- a/crates/media-sort-gui/src/update/tasks.rs
+++ b/crates/media-sort-gui/src/update/tasks.rs
@@ -214,8 +214,11 @@ pub fn scroll_to_selected_entry(state: &AppState, index: usize) -> Task<Message>
 
     let scroll = &state.media_grid.scroll;
 
-    let relative_x = if scroll.viewport_width > 0.0 && scroll.content_width > scroll.viewport_width
-    {
+    let relative_x = if scroll.viewport_width > 0.0 {
+        if scroll.content_width <= scroll.viewport_width {
+            return Task::none();
+        }
+
         let margin = card_stride * 1.5;
         let Some(target_offset) = calculate_scroll_into_view_h(
             item_left,
@@ -355,32 +358,35 @@ pub fn scroll_to_selected_folder(state: &mut AppState) -> Task<Message> {
 
     let scroll = &state.folder.scroll;
 
-    let relative_y =
-        if scroll.viewport_height > 0.0 && scroll.content_height > scroll.viewport_height {
-            let item_height = scroll.content_height / total as f32;
-            let item_top = idx as f32 * item_height;
-            let item_bottom = item_top + item_height;
-            let margin = (scroll.viewport_height * 0.15).clamp(26.0, 78.0);
+    let relative_y = if scroll.viewport_height > 0.0 {
+        if scroll.content_height <= scroll.viewport_height {
+            return Task::none();
+        }
 
-            let Some(target_offset) = calculate_scroll_into_view_v(
-                item_top,
-                item_bottom,
-                scroll.offset_y,
-                scroll.viewport_height,
-                scroll.content_height,
-                margin,
-            ) else {
-                return Task::none();
-            };
+        let item_height = scroll.content_height / total as f32;
+        let item_top = idx as f32 * item_height;
+        let item_bottom = item_top + item_height;
+        let margin = (scroll.viewport_height * 0.15).clamp(26.0, 78.0);
 
-            let max_offset = scroll.content_height - scroll.viewport_height;
-            (target_offset / max_offset).clamp(0.0, 1.0)
-        } else {
-            let Some(rel) = relative_position_for(idx, total) else {
-                return Task::none();
-            };
-            rel
+        let Some(target_offset) = calculate_scroll_into_view_v(
+            item_top,
+            item_bottom,
+            scroll.offset_y,
+            scroll.viewport_height,
+            scroll.content_height,
+            margin,
+        ) else {
+            return Task::none();
         };
+
+        let max_offset = scroll.content_height - scroll.viewport_height;
+        (target_offset / max_offset).clamp(0.0, 1.0)
+    } else {
+        let Some(rel) = relative_position_for(idx, total) else {
+            return Task::none();
+        };
+        rel
+    };
 
     iced::widget::operation::snap_to(
         FOLDER_TREE_SCROLLABLE_ID.clone(),

--- a/crates/media-sort-gui/src/update/tasks.rs
+++ b/crates/media-sort-gui/src/update/tasks.rs
@@ -310,8 +310,8 @@ pub fn calculate_scroll_into_view_1d(
     let item_size = (item_end - item_start).max(0.0);
     let effective_margin = margin.min((viewport_size - item_size).max(0.0) / 2.0);
 
-    let view_start = current_offset;
-    let view_end = current_offset + viewport_size;
+    let view_start = current_offset.clamp(0.0, max_offset);
+    let view_end = view_start + viewport_size;
 
     let target_offset = if item_start - effective_margin < view_start {
         (item_start - effective_margin).max(0.0)

--- a/crates/media-sort-gui/src/update/tests.rs
+++ b/crates/media-sort-gui/src/update/tests.rs
@@ -849,6 +849,11 @@ fn test_calculate_scroll_into_view_1d() {
         calculate_scroll_into_view_1d(390.0, 410.0, 0.0, 400.0, 1000.0, 20.0),
         Some(30.0)
     );
+    // Stale scroll offset beyond content bounds (e.g. after list shrinks) is clamped safely
+    assert_eq!(
+        calculate_scroll_into_view_1d(50.0, 100.0, 800.0, 400.0, 600.0, 20.0),
+        Some(30.0)
+    );
 }
 
 #[test]

--- a/crates/media-sort-gui/src/update/tests.rs
+++ b/crates/media-sort-gui/src/update/tests.rs
@@ -1,7 +1,4 @@
-use super::tasks::{
-    calculate_scroll_into_view_1d, calculate_scroll_into_view_h, calculate_scroll_into_view_v,
-    relative_position_for,
-};
+use super::tasks::{calculate_scroll_into_view_1d, relative_position_for};
 use super::*;
 use crate::message::{FolderMessage, MediaMessage, Message, SettingsMessage, VideoMessage};
 use crate::state::{AppState, SettingsUiState};
@@ -787,68 +784,35 @@ fn test_relative_position_for_scrolling() {
 }
 
 #[test]
-fn test_calculate_scroll_into_view_h() {
-    // When viewport size is 0 or content fits in viewport, no scrolling
+fn test_calculate_scroll_into_view_1d() {
+    // When viewport size is 0 or content fits in viewport, no scrolling needed
     assert_eq!(
-        calculate_scroll_into_view_h(0.0, 60.0, 0.0, 0.0, 1000.0, 50.0),
+        calculate_scroll_into_view_1d(0.0, 60.0, 0.0, 0.0, 1000.0, 50.0),
         None
     );
     assert_eq!(
-        calculate_scroll_into_view_h(0.0, 60.0, 0.0, 600.0, 500.0, 50.0),
+        calculate_scroll_into_view_1d(0.0, 60.0, 0.0, 600.0, 500.0, 50.0),
         None
     );
 
     // Item already comfortably visible with margin: no scroll needed
     assert_eq!(
-        calculate_scroll_into_view_h(200.0, 260.0, 100.0, 600.0, 2000.0, 50.0),
+        calculate_scroll_into_view_1d(200.0, 260.0, 100.0, 600.0, 2000.0, 50.0),
         None
     );
 
-    // Item too close to or past right edge: scroll right to bring into view with margin
+    // Item too close to or past trailing edge: scroll forward to bring into view with margin
     assert_eq!(
-        calculate_scroll_into_view_h(600.0, 660.0, 100.0, 600.0, 2000.0, 50.0),
+        calculate_scroll_into_view_1d(600.0, 660.0, 100.0, 600.0, 2000.0, 50.0),
         Some(110.0)
     );
 
-    // Item past left edge: scroll left to bring into view with margin
+    // Item past leading edge: scroll backward to bring into view with margin
     assert_eq!(
-        calculate_scroll_into_view_h(60.0, 120.0, 200.0, 600.0, 2000.0, 50.0),
+        calculate_scroll_into_view_1d(60.0, 120.0, 200.0, 600.0, 2000.0, 50.0),
         Some(10.0)
     );
-}
 
-#[test]
-fn test_calculate_scroll_into_view_v() {
-    // Item comfortably visible: no scroll needed
-    assert_eq!(
-        calculate_scroll_into_view_v(100.0, 126.0, 50.0, 500.0, 2000.0, 30.0),
-        None
-    );
-
-    // Item past bottom edge: scroll down
-    assert_eq!(
-        calculate_scroll_into_view_v(500.0, 526.0, 0.0, 500.0, 2000.0, 30.0),
-        Some(56.0)
-    );
-
-    // Item past top edge: scroll up
-    assert_eq!(
-        calculate_scroll_into_view_v(10.0, 36.0, 100.0, 500.0, 2000.0, 30.0),
-        Some(0.0)
-    );
-}
-
-#[test]
-fn test_calculate_scroll_into_view_1d() {
-    // Both H and V delegate to 1D and produce identical results
-    assert_eq!(
-        calculate_scroll_into_view_1d(100.0, 150.0, 0.0, 400.0, 1000.0, 20.0),
-        None
-    );
-    assert_eq!(
-        calculate_scroll_into_view_1d(390.0, 410.0, 0.0, 400.0, 1000.0, 20.0),
-        Some(30.0)
-    );
     // Stale scroll offset beyond content bounds (e.g. after list shrinks) is clamped safely
     assert_eq!(
         calculate_scroll_into_view_1d(50.0, 100.0, 800.0, 400.0, 600.0, 20.0),

--- a/crates/media-sort-gui/src/update/tests.rs
+++ b/crates/media-sort-gui/src/update/tests.rs
@@ -1,4 +1,6 @@
-use super::tasks::relative_position_for;
+use super::tasks::{
+    calculate_scroll_into_view_h, calculate_scroll_into_view_v, relative_position_for,
+};
 use super::*;
 use crate::message::{FolderMessage, MediaMessage, Message, SettingsMessage, VideoMessage};
 use crate::state::{AppState, SettingsUiState};
@@ -781,6 +783,58 @@ fn test_relative_position_for_scrolling() {
     assert_eq!(relative_position_for(0, 0), None);
     assert_eq!(relative_position_for(0, 1), None);
     assert_eq!(relative_position_for(99, 7), Some(1.0));
+}
+
+#[test]
+fn test_calculate_scroll_into_view_h() {
+    // When viewport size is 0 or content fits in viewport, no scrolling
+    assert_eq!(
+        calculate_scroll_into_view_h(0.0, 60.0, 0.0, 0.0, 1000.0, 50.0),
+        None
+    );
+    assert_eq!(
+        calculate_scroll_into_view_h(0.0, 60.0, 0.0, 600.0, 500.0, 50.0),
+        None
+    );
+
+    // Item already comfortably visible with margin: no scroll needed
+    assert_eq!(
+        calculate_scroll_into_view_h(200.0, 260.0, 100.0, 600.0, 2000.0, 50.0),
+        None
+    );
+
+    // Item too close to or past right edge: scroll right to bring into view with margin
+    assert_eq!(
+        calculate_scroll_into_view_h(600.0, 660.0, 100.0, 600.0, 2000.0, 50.0),
+        Some(110.0)
+    );
+
+    // Item past left edge: scroll left to bring into view with margin
+    assert_eq!(
+        calculate_scroll_into_view_h(60.0, 120.0, 200.0, 600.0, 2000.0, 50.0),
+        Some(10.0)
+    );
+}
+
+#[test]
+fn test_calculate_scroll_into_view_v() {
+    // Item comfortably visible: no scroll needed
+    assert_eq!(
+        calculate_scroll_into_view_v(100.0, 126.0, 50.0, 500.0, 2000.0, 30.0),
+        None
+    );
+
+    // Item past bottom edge: scroll down
+    assert_eq!(
+        calculate_scroll_into_view_v(500.0, 526.0, 0.0, 500.0, 2000.0, 30.0),
+        Some(56.0)
+    );
+
+    // Item past top edge: scroll up
+    assert_eq!(
+        calculate_scroll_into_view_v(10.0, 36.0, 100.0, 500.0, 2000.0, 30.0),
+        Some(0.0)
+    );
 }
 
 #[test]

--- a/crates/media-sort-gui/src/update/tests.rs
+++ b/crates/media-sort-gui/src/update/tests.rs
@@ -1,5 +1,6 @@
 use super::tasks::{
-    calculate_scroll_into_view_h, calculate_scroll_into_view_v, relative_position_for,
+    calculate_scroll_into_view_1d, calculate_scroll_into_view_h, calculate_scroll_into_view_v,
+    relative_position_for,
 };
 use super::*;
 use crate::message::{FolderMessage, MediaMessage, Message, SettingsMessage, VideoMessage};
@@ -834,6 +835,19 @@ fn test_calculate_scroll_into_view_v() {
     assert_eq!(
         calculate_scroll_into_view_v(10.0, 36.0, 100.0, 500.0, 2000.0, 30.0),
         Some(0.0)
+    );
+}
+
+#[test]
+fn test_calculate_scroll_into_view_1d() {
+    // Both H and V delegate to 1D and produce identical results
+    assert_eq!(
+        calculate_scroll_into_view_1d(100.0, 150.0, 0.0, 400.0, 1000.0, 20.0),
+        None
+    );
+    assert_eq!(
+        calculate_scroll_into_view_1d(390.0, 410.0, 0.0, 400.0, 1000.0, 20.0),
+        Some(30.0)
     );
 }
 

--- a/crates/media-sort-gui/src/view/folder_panel.rs
+++ b/crates/media-sort-gui/src/view/folder_panel.rs
@@ -65,6 +65,14 @@ pub fn folder_panel_view(state: &AppState) -> Element<'_, Message> {
             vertical: iced::widget::scrollable::Scrollbar::default(),
             horizontal: iced::widget::scrollable::Scrollbar::default(),
         })
+        .on_scroll(|viewport| {
+            let offset = viewport.absolute_offset();
+            Message::Folder(FolderMessage::TreeScrolled(
+                offset,
+                viewport.bounds().height,
+                viewport.content_bounds().height,
+            ))
+        })
         .width(Length::Fill)
         .height(Length::Fill);
 

--- a/crates/media-sort-gui/src/view/folder_tree.rs
+++ b/crates/media-sort-gui/src/view/folder_tree.rs
@@ -230,6 +230,7 @@ fn render_node<'a>(
     } else {
         let button_element = button(row_content)
             .on_press(Message::Folder(folder_action))
+            .padding([4, 8])
             .style(move |theme: &iced::Theme, _status| {
                 let palette = theme.palette();
                 let base = iced::widget::button::Style::default();


### PR DESCRIPTION
## Description
Replaces proportional auto-scrolling (`index / (n - 1)`) with standard scroll-into-view behavior with scroll margins for both the media grid (horizontal) and folder tree (vertical).

## Summary of Changes
- **Media Grid**: Active thumbnail card auto-scrolls only when reaching or passing viewport margins (1.5 card stride), keeping adjacent cards visible. No viewport shifts occur when navigating within visible cards.
- **Folder Tree**: Tracked vertical scroll position and added scroll margins to ensure folder tree selection keeps surrounding folders visible.
- **Tests**: Added tests for horizontal and vertical scroll offset calculations in `update/tests.rs`.